### PR TITLE
Improve type info for HTML elements

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,17 +1,20 @@
-import { type AttributesByTagName } from './attributes.js'
+import type { AttributesByTagName } from './attributes.js'
 import type { PossiblyDeferredHTML } from './createElement.js'
-import { type VoidElementTagName } from './voidElements.js'
+import type { VoidElementTagName } from './voidElements.js'
 
 export { createElement } from './createElement.js'
 
 // See <https://www.typescriptlang.org/docs/handbook/jsx.html>.
 export declare namespace createElement.JSX {
-  type IntrinsicElements = {
-    [TagName in keyof AttributesByTagName]: AttributesByTagName[TagName] & {
+  type HTML<TagName extends keyof AttributesByTagName> =
+    AttributesByTagName[TagName] & {
       readonly [_children]?: TagName extends VoidElementTagName
         ? undefined
         : Element | readonly Element[]
     }
+
+  type IntrinsicElements = {
+    [TagName in keyof AttributesByTagName]: HTML<TagName>
   }
 
   type ElementChildrenAttribute = {


### PR DESCRIPTION
Before:
<img width="642" height="356" alt="Screenshot 2025-09-21 at 6 27 49 PM" src="https://github.com/user-attachments/assets/c7473661-561b-4a0d-95ae-886a905fcf5d" />

After:
<img width="639" height="171" alt="Screenshot 2025-09-21 at 6 26 04 PM" src="https://github.com/user-attachments/assets/c314af2f-a3d4-4502-ad8a-0880d6d09d1e" />
