### PR TITLE
Accept promises of `ReadableHTMLTokenStream`s as children

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties, HTMLElements, ValueSets } from '@michijs/htmltype'
 import type { HTMLToken } from './htmlToken.js'
 import { readableStreamFromIterable } from './readableStream.js'
+import type { Primitive } from './utilityTypes.js'
 
 /**
  * Attribute values are specifically-typed based on the tag and attribute name.
@@ -94,8 +95,6 @@ type UnknownAttributes = {
     | Promise<string>
     | AsyncIterable<string>
 }
-
-type Primitive = string | number | bigint | boolean | symbol | null | undefined
 
 /**
  * Throws an error if the attribute name is malformed or if the value has an

--- a/src/createElement.test.ts
+++ b/src/createElement.test.ts
@@ -103,6 +103,14 @@ suite('createElement', _ => {
       ),
       ['<div', '>', '&lt;&amp;&gt;', '</div>'],
     ))
+
+  test('promise of stream content', async _ =>
+    assert.deepEqual(
+      await asArrayOfHTMLFragments(
+        createElement('div', {}, Promise.resolve(createElement('div', {}))),
+      ),
+      ['<div', '>', '<div', '>', '</div>', '</div>'],
+    ))
 })
 
 // Type-level tests:

--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -7,6 +7,7 @@ import {
   concatReadableStreams,
   readableStreamFromChunk,
   readableStreamFromIterable,
+  readableStreamFromPromise,
 } from './readableStream.js'
 import type { TagName } from './tagName.js'
 import { TextCapturingTransformStream } from './transformStreams.js'
@@ -81,8 +82,9 @@ type CreateFragmentParameters = readonly [
 type Child =
   | string
   | Promise<string>
+  | Promise<ReadableHTMLTokenStream>
   | AsyncIterable<string>
-  | AsyncIterable<HTMLToken>
+  | ReadableHTMLTokenStream
 
 const childToReadableHTMLTokenStream = (
   child: Child,
@@ -90,7 +92,9 @@ const childToReadableHTMLTokenStream = (
   let stream =
     typeof child === 'object' && Symbol.asyncIterator in child
       ? readableStreamFromIterable<HTMLToken | string>(child)
-      : readableStreamFromChunk(child)
+      : typeof child === 'string'
+      ? readableStreamFromChunk(child)
+      : readableStreamFromPromise<HTMLToken | string>(child)
 
   return stream.pipeThrough(new TextCapturingTransformStream())
 }

--- a/src/jsx.test.tsx
+++ b/src/jsx.test.tsx
@@ -235,6 +235,12 @@ suite('jsx', _ => {
       '</div>',
     ])
   })
+
+  test('promise of stream content children', async _ =>
+    assert.deepEqual(
+      await asArrayOfHTMLFragments(<div>{Promise.resolve(<div></div>)}</div>),
+      ['<div', '>', '<div', '>', '</div>', '</div>'],
+    ))
 })
 
 // Type-level tests:

--- a/src/utilityTypes.ts
+++ b/src/utilityTypes.ts
@@ -1,0 +1,8 @@
+export type Primitive =
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | null
+  | undefined


### PR DESCRIPTION
Code like this is now legal:

```tsx
const getChildAsynchronously = async () => {
  const text = await getTextFromSomeAsyncSource()
  return <span>{text}</span>
}

const element = <div>{getChildAsynchronously()}</div>
```