### PR TITLE
Fix HTML descriptions in type info

### DIFF
--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -17,7 +17,9 @@ export declare namespace createElement.JSX {
     }
 
   type IntrinsicElements = {
-    readonly [SpecificTagName in TagName]: HTML<SpecificTagName>
+    // Using `keyof AttributesByTagName` rather than `TagName` here is necessary
+    // to maintain documentation in type info.
+    readonly [SpecificTagName in keyof AttributesByTagName]: HTML<SpecificTagName>
   }
 
   type ElementChildrenAttribute = {


### PR DESCRIPTION
I apparently broke this back in 300ad402cf54c247df3e570c89616d786b2dde04.