### PR TITLE
Generalize `Promise` children to allow more types

### DIFF
--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -81,8 +81,7 @@ type CreateFragmentParameters = readonly [
 
 type Child =
   | string
-  | Promise<string>
-  | Promise<ReadableHTMLTokenStream>
+  | Promise<string | ReadableStream<string> | ReadableHTMLTokenStream>
   | AsyncIterable<string>
   | ReadableHTMLTokenStream
 

--- a/src/readableStream.ts
+++ b/src/readableStream.ts
@@ -37,7 +37,7 @@ export const concatReadableStreams = <T>(
 }
 
 export const readableStreamFromPromise = <R>(
-  promise: Promise<R & Primitive> | Promise<HasDefaultReader<R>>,
+  promise: Promise<(R & Primitive) | HasDefaultReader<R>>,
 ): ReadableStream<R> =>
   new ReadableStream({
     start: async controller => {


### PR DESCRIPTION
Notably, `Promise<ReadableStream<string>>` is now allowed.