### PR TITLE
Encode fewer HTML entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@michijs/htmltype": "0.4.9",
-        "html-entities": "^2.6.0",
         "html-tags": "^5.1.0"
       },
       "devDependencies": {
@@ -72,22 +71,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/html-tags": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "//": "Note: @michijs/htmltype 0.4.10 is broken (see https://github.com/michijs/htmltype/issues/257), so it's locked specifically to 0.4.9 below.",
   "dependencies": {
     "@michijs/htmltype": "0.4.9",
-    "html-entities": "^2.6.0",
     "html-tags": "^5.1.0"
   },
   "devDependencies": {

--- a/src/createElement.test.ts
+++ b/src/createElement.test.ts
@@ -73,7 +73,7 @@ suite('createElement', _ => {
   test('element with escaped text content', async _ =>
     assert.deepEqual(
       await asArrayOfHTMLFragments(createElement('div', {}, '<&>')),
-      ['<div', '>', '&lt;&amp;&gt;', '</div>'],
+      ['<div', '>', '&lt;&amp;>', '</div>'],
     ))
 
   test('false boolean attribute', async _ =>
@@ -93,7 +93,7 @@ suite('createElement', _ => {
       await asArrayOfHTMLFragments(
         createElement('div', {}, Promise.resolve('<&>')),
       ),
-      ['<div', '>', '&lt;&amp;&gt;', '</div>'],
+      ['<div', '>', '&lt;&amp;>', '</div>'],
     ))
 
   test('stream content', async _ =>
@@ -101,7 +101,7 @@ suite('createElement', _ => {
       await asArrayOfHTMLFragments(
         createElement('div', {}, readableStreamFromChunk('<&>')),
       ),
-      ['<div', '>', '&lt;&amp;&gt;', '</div>'],
+      ['<div', '>', '&lt;&amp;>', '</div>'],
     ))
 
   test('promise of stream content', async _ =>

--- a/src/jsx.test.tsx
+++ b/src/jsx.test.tsx
@@ -136,7 +136,7 @@ suite('jsx', _ => {
   test('element with event handler attribute', async _ => {
     assert.deepEqual(
       await asArrayOfHTMLFragments(<div onclick="alert('hi')"></div>),
-      ['<div', ' onclick="alert(&apos;hi&apos;)"', '>', '</div>'],
+      ['<div', ' onclick="alert(\'hi\')"', '>', '</div>'],
     )
   })
 
@@ -181,7 +181,7 @@ suite('jsx', _ => {
     assert.deepEqual(await asArrayOfHTMLFragments(<div>{'<&>'}</div>), [
       '<div',
       '>',
-      '&lt;&amp;&gt;',
+      '&lt;&amp;>',
       '</div>',
     ]))
 
@@ -230,7 +230,7 @@ suite('jsx', _ => {
   test('stream content', async _ =>
     assert.deepEqual(
       await asArrayOfHTMLFragments(<div>{readableStreamFromChunk('<&>')}</div>),
-      ['<div', '>', '&lt;&amp;&gt;', '</div>'],
+      ['<div', '>', '&lt;&amp;>', '</div>'],
     ))
 
   test('array children', async _ => {
@@ -257,7 +257,7 @@ suite('jsx', _ => {
           {Promise.resolve(readableStreamFromIterable(['a', '<&>', 'b']))}
         </div>,
       ),
-      ['<div', '>', 'a', '&lt;&amp;&gt;', 'b', '</div>'],
+      ['<div', '>', 'a', '&lt;&amp;>', 'b', '</div>'],
     ))
 
   test('consume DOM children', async _ => {

--- a/src/transformStreams.ts
+++ b/src/transformStreams.ts
@@ -1,4 +1,3 @@
-import * as htmlEntities from 'html-entities'
 import { type HTMLToken } from './htmlToken.js'
 import type { TagName } from './tagName.js'
 import { isVoidElementTagName } from './voidElements.js'
@@ -63,14 +62,19 @@ const htmlTokenToHTMLFragment = (
 ): SerializedHTMLFragment => {
   switch (chunk.kind) {
     case 'text':
-      return escapeHTMLContent(chunk.text)
+      return encodeTextContent(chunk.text)
     case 'startOfOpeningTag':
       return '<'.concat(chunk.tagName) as SerializedHTMLFragment
     case 'attribute':
       return (
         chunk.value === ''
           ? ' '.concat(chunk.name)
-          : ' '.concat(chunk.name, '="', escapeHTMLContent(chunk.value), '"')
+          : ' '.concat(
+              chunk.name,
+              '="',
+              encodeDoubleQuotedAttributeContent(chunk.value),
+              '"',
+            )
       ) as SerializedHTMLFragment
     case 'endOfOpeningTag':
       return '>' as SerializedHTMLFragment
@@ -88,9 +92,30 @@ const htmlTokenToHTMLFragment = (
   }
 }
 
-const escapeHTMLContent = (content: string): SerializedHTMLFragment =>
-  htmlEntities.encode(content, {
-    mode: 'specialChars',
-    level: 'html5',
-    numeric: 'hexadecimal',
-  }) as SerializedHTMLFragment
+const textContentEncodings: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+}
+const textContentEncodingPattern = new RegExp(
+  `[${Object.keys(textContentEncodings).join('')}]`,
+  'g',
+)
+const encodeTextContent = (content: string) =>
+  content.replace(
+    textContentEncodingPattern,
+    character => textContentEncodings[character] ?? character,
+  ) as SerializedHTMLFragment
+
+const doubleQuotedAttributeContentEncodings: Record<string, string> = {
+  '&': '&amp;',
+  '"': '&quot;',
+}
+const doubleQuotedAttributeContentEncodingPattern = new RegExp(
+  `[${Object.keys(doubleQuotedAttributeContentEncodings).join('')}]`,
+  'g',
+)
+const encodeDoubleQuotedAttributeContent = (content: string) =>
+  content.replace(
+    doubleQuotedAttributeContentEncodingPattern,
+    character => doubleQuotedAttributeContentEncodings[character] ?? character,
+  ) as SerializedHTMLFragment


### PR DESCRIPTION
Silk now separately encodes a minimal set of strictly-necessary entities for attribute values and text content.

I was motivated to do this while trying to use Silk to emit CSS text within a `<style>` element: I was being thwarted because CSS-relevant characters (like `'`/`"`/`>`) were getting unnecessarily encoded.

This changeset also drops the [`html-entities`](https://www.npmjs.com/package/html-entities) dependency.